### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -19,6 +19,6 @@
     "Intl::Format::Unit": "lib/Intl/Format/Unit.pm6"
   },
   "resources": [],
-  "license": "Artist-2.0",
+  "license": "Artistic-2.0",
   "source-url": "git://github.com/alabamenhu/IntlFormatUnit.git"
 }


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module